### PR TITLE
Fixed for Django 3.0 and added RWD

### DIFF
--- a/admin_toolbox/templates/admin/base.html
+++ b/admin_toolbox/templates/admin/base.html
@@ -1,19 +1,24 @@
-{% load i18n admin_static admin_toolbox_sidebar admin_toolbox_breadcrumbs %}<!DOCTYPE html>
+{% load i18n static %}{% load admin_toolbox_sidebar admin_toolbox_breadcrumbs %}<!DOCTYPE html>
 {% get_current_language as LANGUAGE_CODE %}{% get_current_language_bidi as LANGUAGE_BIDI %}
 <html lang="{{ LANGUAGE_CODE|default:"en-us" }}" {% if LANGUAGE_BIDI %}dir="rtl"{% endif %}
       class="{% if request.user.is_authenticated %}w-su-sidebar{% endif %}">
 <head>
 <title>{% block title %}{% endblock %}</title>
-<link rel="stylesheet" type="text/css" href="{% block stylesheet %}{% static "admin/css/base.css" %}{% endblock %}" />
-    <link rel="stylesheet" type="text/css" href="{% static "admin_sidebar/font-awesome/css/all.min.css" %}" />
-  <link rel="stylesheet" type="text/css" href="{% static "admin_sidebar/font-awesome/css/v4-shims.min.css" %}" />
-<link rel="stylesheet" type="text/css" href="{% static "admin_sidebar/css/admin-sidebar.css" %}" />
+<link rel="stylesheet" type="text/css" href="{% block stylesheet %}{% static "admin/css/base.css" %}{% endblock %}">
+<link rel="stylesheet" type="text/css" href="{% static "admin_sidebar/font-awesome/css/all.min.css" %}">
+<link rel="stylesheet" type="text/css" href="{% static "admin_sidebar/font-awesome/css/v4-shims.min.css" %}">
+<link rel="stylesheet" type="text/css" href="{% static "admin_sidebar/css/admin-sidebar.css" %}">
 {% block extrastyle %}{% endblock %}
-{% if LANGUAGE_BIDI %}<link rel="stylesheet" type="text/css" href="{% block stylesheet_rtl %}{% static "admin/css/rtl.css" %}{% endblock %}" />{% endif %}
+{% if LANGUAGE_BIDI %}<link rel="stylesheet" type="text/css" href="{% block stylesheet_rtl %}{% static "admin/css/rtl.css" %}{% endblock %}">{% endif %}
 <script type="text/javascript" src="{% static "admin/js/vendor/jquery/jquery.js" %}"></script>
 <script type="text/javascript" src="{% static "admin/js/jquery.init.js" %}"></script>
 {% block extrahead %}{% endblock %}
-{% block blockbots %}<meta name="robots" content="NONE,NOARCHIVE" />{% endblock %}
+{% block responsive %}
+    <meta name="viewport" content="user-scalable=no, width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <link rel="stylesheet" type="text/css" href="{% static "admin/css/responsive.css" %}">
+    {% if LANGUAGE_BIDI %}<link rel="stylesheet" type="text/css" href="{% static "admin/css/responsive_rtl.css" %}">{% endif %}
+{% endblock %}
+{% block blockbots %}<meta name="robots" content="NONE,NOARCHIVE">{% endblock %}
 </head>
 {% load i18n %}
 
@@ -24,74 +29,75 @@
 <div id="container">
 
     {% if not is_popup %}
-        <!-- Header -->
-        <div id="header">
-            <div id="branding">
-                {% block branding %}{% endblock %}
-            </div>
-            {% block usertools %}
-            {% if has_permission %}
-            <div id="user-tools">
-                {% block welcome-msg %}
-                    {% trans 'Welcome,' %}
-                    <strong>{% firstof user.get_short_name user.get_username %}</strong>.
-                {% endblock %}
-                {% block userlinks %}
-                    {% if site_url %}
-                        <a href="{{ site_url }}">{% trans 'View site' %}</a> /
-                    {% endif %}
-                    {% if user.is_active and user.is_staff %}
-                        {% url 'django-admindocs-docroot' as docsroot %}
-                        {% if docsroot %}
-                            <a href="{{ docsroot }}">{% trans 'Documentation' %}</a> /
-                        {% endif %}
-                    {% endif %}
-                    {% if user.has_usable_password %}
-                    <a href="{% url 'admin:password_change' %}">{% trans 'Change password' %}</a> /
-                    {% endif %}
-                    <a href="{% url 'admin:logout' %}">{% trans 'Log out' %}</a>
-                {% endblock %}
-            </div>
-            {% endif %}
-            {% endblock %}
-            {% block nav-global %}{% endblock %}
+    <!-- Header -->
+    <div id="header">
+        <div id="branding">
+        {% block branding %}{% endblock %}
         </div>
-        <!-- END Header -->
-          {% rebreadcrumbs %}
-            {% block breadcrumbs %}
-            <div class="breadcrumbs">
-            <a href="{% url 'admin:index' %}">{% trans 'Home' %}</a>
-            {% if title %} &rsaquo; {{ title }}{% endif %}
-            </div>
+        {% block usertools %}
+        {% if has_permission %}
+        <div id="user-tools">
+            {% block welcome-msg %}
+                {% trans 'Welcome,' %}
+                <strong>{% firstof user.get_short_name user.get_username %}</strong>.
             {% endblock %}
-          {% endrebreadcrumbs %}
-        {% if request.user.is_authenticated %}
-        <div id="su-content">
-            {% admin_sidebar_content %}
+            {% block userlinks %}
+                {% if site_url %}
+                    <a href="{{ site_url }}">{% trans 'View site' %}</a> /
+                {% endif %}
+                {% if user.is_active and user.is_staff %}
+                    {% url 'django-admindocs-docroot' as docsroot %}
+                    {% if docsroot %}
+                        <a href="{{ docsroot }}">{% trans 'Documentation' %}</a> /
+                    {% endif %}
+                {% endif %}
+                {% if user.has_usable_password %}
+                <a href="{% url 'admin:password_change' %}">{% trans 'Change password' %}</a> /
+                {% endif %}
+                <a href="{% url 'admin:logout' %}">{% trans 'Log out' %}</a>
+            {% endblock %}
+        </div>
         {% endif %}
+        {% endblock %}
+        {% block nav-global %}{% endblock %}
+    </div>
+    <!-- END Header -->
+    {% rebreadcrumbs %}
+    {% block breadcrumbs %}
+    <div class="breadcrumbs">
+    <a href="{% url 'admin:index' %}">{% trans 'Home' %}</a>
+    {% if title %} &rsaquo; {{ title }}{% endif %}
+    </div>
+    {% endblock %}
+    {% endrebreadcrumbs %}
+    {% if request.user.is_authenticated %}
+    <div id="su-content">
+        {% admin_sidebar_content %}
+    {% endif %}
     {% endif %}
 
-        {% block messages %}
-            {% if messages %}
-                <ul class="messagelist">{% for message in messages %}
-                    <li{% if message.tags %} class="{{ message.tags }}"{% endif %}>{{ message|capfirst }}</li>
-                {% endfor %}</ul>
-            {% endif %}
-        {% endblock messages %}
+    {% block messages %}
+        {% if messages %}
+        <ul class="messagelist">{% for message in messages %}
+          <li{% if message.tags %} class="{{ message.tags }}"{% endif %}>{{ message|capfirst }}</li>
+        {% endfor %}</ul>
+        {% endif %}
+    {% endblock messages %}
 
-        <!-- Content -->
-        <div id="content" class="{% block coltype %}colM{% endblock %}">
-            {% block pretitle %}{% endblock %}
-            {% block content_title %}{% if title %}<h1>{{ title }}</h1>{% endif %}{% endblock %}
-            {% block content %}
-                {% block object-tools %}{% endblock %}
-                {{ content }}
-            {% endblock %}
-            {% block sidebar %}{% endblock %}
-            <br class="clear" />
-        </div>
-        <!-- END Content -->
-        {% block footer %}<div id="footer"></div>{% endblock %}
+    <!-- Content -->
+    <div id="content" class="{% block coltype %}colM{% endblock %}">
+        {% block pretitle %}{% endblock %}
+        {% block content_title %}{% if title %}<h1>{{ title }}</h1>{% endif %}{% endblock %}
+        {% block content %}
+        {% block object-tools %}{% endblock %}
+        {{ content }}
+        {% endblock %}
+        {% block sidebar %}{% endblock %}
+        <br class="clear">
+    </div>
+    <!-- END Content -->
+
+    {% block footer %}<div id="footer"></div>{% endblock %}
     {% if not is_popup and request.user.is_authenticated %}</div>{% endif %}
 
 </div>


### PR DESCRIPTION
- On Django 2.1, `admin_static` was deprecated and removed in Django 3.0
  in favor of plain `static`. This change is backwards compatible with
  Django 2.0 and Django 1.11, as it was already just an alias for
  `static` on those versions of Django.
- Added missing admin RWD styles introduced in Django 2.0. This change
  may introduce some 404 errors on Django 1.11, as those stylesheet
  files are not present on this Django version. If this is an issue,
  create `admin/base_site.html` template being an exact copy of original
  Django `admin/base_site.html` template and add empty `responsive`
  block into it.
- Reverted indentation and HTML tags ending style of customized 
  `admin/base.html` file to match original Django file. This makes 
  spotting any changes of this file in new Django versions easier.