### PR TITLE
Ability to choose sidebar by context variable

### DIFF
--- a/admin_toolbox/templatetags/admin_toolbox_sidebar.py
+++ b/admin_toolbox/templatetags/admin_toolbox_sidebar.py
@@ -13,9 +13,10 @@ register = template.Library()
 
 
 @register.inclusion_tag('admin_toolbox/sidebar.html', takes_context=True)
-def admin_sidebar_content(context, menu_name='default'):
+def admin_sidebar_content(context, menu_name=None):
 
     request = context.request
+    menu_name = menu_name or context.get('toolbox_sidebar_name') or 'default'
 
     config = settings.sidebar.get(menu_name)
 


### PR DESCRIPTION
Added ability to choose which sidebar should be rendered (defaults to
`default` by specifying `toolbox_sidebar_name` context variable.